### PR TITLE
chore: removed range from npc spells

### DIFF
--- a/src/external/fultimator.ts
+++ b/src/external/fultimator.ts
@@ -58,7 +58,6 @@ export type NpcSpell = {
 	target?: string;
 	duration?: string;
 	name: string;
-	range: string;
 	type: string | null;
 	attr1: Attributes;
 	attr2: Attributes;


### PR DESCRIPTION
This field is redundant now.