### PR TITLE
fix: items are not appearing in Project FU 2.4.0-alphas

### DIFF
--- a/src/external/project-fu.ts
+++ b/src/external/project-fu.ts
@@ -44,6 +44,7 @@ declare global {
 type Folder = {
 	_id: string;
 	name: string;
+	type: string;
 	getSubfolders(): Collection<Folder>;
 };
 
@@ -82,7 +83,8 @@ export const getFolder = async (folders: readonly string[], type: string) => {
 				(await Folder.create({ name: folderName, type, folder: folder._id }));
 		} else {
 			folder =
-				game.folders.find((f) => f.name === folderName) || (await Folder.create({ name: folderName, type }));
+				game.folders.find((f) => f.name === folderName && f.type == type) ||
+				(await Folder.create({ name: folderName, type }));
 		}
 	}
 	return folder;


### PR DESCRIPTION
Project FU 2.4.0 alphas have added a compendium. The folder creation in fu-parser was not filtering by the folder type, so when it looked up the "Equipment" folder it was finding the compendium folder.  This made it so that the items would not show up in any of the sidebars.

This patch filters the folder type so that items will search for an 'Item' folder of the correct name, and similarly actors will search for an 'Actor' folder.